### PR TITLE
fix: codeblock formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Format a string as a code block.
 
 ```js
 md.codeBlock('console.log("Hello, World!");', "js");
-// => "```js\nconsole.log("Hello, World!");\n```"
+// => "```js\nconsole.log("Hello, World!");```"
 ```
 
 ### `heading(text, level)`

--- a/src/render.ts
+++ b/src/render.ts
@@ -88,7 +88,7 @@ export function image(
  *
  * ```js
  * md.codeBlock('console.log("Hello, World!");', "js");
- * // => "```js\nconsole.log("Hello, World!");\n```"
+ * // => "```js\nconsole.log("Hello, World!");```"
  * ```
  *
  * @param code Text to be formattted as code block
@@ -104,7 +104,7 @@ export function codeBlock(
   lang?: string,
   opts?: { ext?: string },
 ): string {
-  return `\`\`\`${lang || ""}${opts?.ext ? ` ${opts.ext}` : ""}\n${code}\n\`\`\``;
+  return `\`\`\`${lang || ""}${opts?.ext ? ` ${opts.ext}` : ""}\n${code}\`\`\``;
 }
 
 /**

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -6,20 +6,17 @@ const renderTests = {
   blockquote: [["Hello, World!", "> Hello, World!"]],
   boldAndItalic: [["Hello, World!", "***Hello, World!***"]],
   codeBlock: [
-    [
-      'console.log("Hello, World!");',
-      '```\nconsole.log("Hello, World!");\n```',
-    ],
+    ['console.log("Hello, World!");', '```\nconsole.log("Hello, World!");```'],
     [
       'console.log("Hello, World!");',
       "js",
       { ext: '[name="index.js"]' },
-      '```js [name="index.js"]\nconsole.log("Hello, World!");\n```',
+      '```js [name="index.js"]\nconsole.log("Hello, World!");```',
     ],
     [
       'console.log("Hello, World!");',
       "js",
-      '```js\nconsole.log("Hello, World!");\n```',
+      '```js\nconsole.log("Hello, World!");```',
     ],
   ],
   strikethrough: [["Hello, World!", "~~Hello, World!~~"]],


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves #32 

As stated in the issue - When you have a file formatter like prettier etc, this space is removed, but every file touch is considered as a "changed" file.

this package is used by the `automd` so the fix is aimed to fix the generation workflow :)
